### PR TITLE
(Fallback Solution) Doxygen Link Resolution

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -74,3 +74,5 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
+
+#### {#codeofconduct}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -75,4 +75,4 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
 
-#### {#codeofconduct}
+#### </b> {#codeofconduct}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,4 +160,4 @@ When working with C++ code, we should use a submodule for third parties if possi
 ### 3. Never modify the third party
 To help with maintainability, third parties should have no modified code in them. When it comes to updating the third party it should be as easy as replacing the current version with the new version.
 
-#### {#contributing}
+#### </b> {#contributing}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Familiarity with Git, specifically with using branches, is a must for interactin
 
 **Hot Fix Branches** are a method for pushing code to the master branch after a release. These should be minor fixes that add no functionality (unless the bug restricts a certain functionality) to the project.
 
-**Release Branches** are the staging area for a release. Similar to a hotfix branch only bug testing is to be done here and no new features should be added. 
+**Release Branches** are the staging area for a release. Similar to a hotfix branch only bug testing is to be done here and no new features should be added.
 - A 3/4 developer approval to push to the release branch.
 - The code must be tested on all supported systems before being pushed here.
 
@@ -89,7 +89,7 @@ Functions should follow the `camelCase` convention, where the first word has a l
 ```cpp
 int doSomething();
 int goddIsTodd();
-int wowThisIsACoolFunction(); 
+int wowThisIsACoolFunction();
 ```
 #### VARIABLES
 There are a few things to know about naming variables. Most all variables must follow the camelCase convention, however, private member variables of a class must use an `m_` prefix before them. However, constants and macros should be ALL_CAPITALS_USING_UNDERSCORES_INSTEAD_OF_SPACES. Hopefully that makes sense, if not, here’s an example to make things make sense:
@@ -129,7 +129,7 @@ Multiline comments should use the /* */ method of commenting, where the /* and *
 When documenting classes, methods and similar we follow the Doxygen Javadoc syntax. For example, this convention should be followed:
 ```cpp
 /**
- * @brief This class is for documentation reasons. 
+ * @brief This class is for documentation reasons.
  */
 class FooBar {
 public:
@@ -139,7 +139,7 @@ public:
 	 * @return A very important integer. (probably an error code or something)
 	 */
   	int doThing(std::string desc);
-  	
+
   	float randomNumber; //< This is a single line description for a member
 
       /// @brief This member variable requires a longer single line comment. (filling space)
@@ -159,3 +159,5 @@ When choosing a third party, we need to make sure the third party is right for o
 When working with C++ code, we should use a submodule for third parties if possible. We also want to keep the third party code seperate from our own source code so it should be placed in the ThirdParties folder of the project.
 ### 3. Never modify the third party
 To help with maintainability, third parties should have no modified code in them. When it comes to updating the third party it should be as easy as replacing the current version with the new version.
+
+#### {#contributing}

--- a/Documentation/Architecture.md
+++ b/Documentation/Architecture.md
@@ -1,7 +1,10 @@
 # Phoenix Architecture
-
 The goal of these documents is to provide an understanding of the architecture of Phoenix. If you just starting to
 contribute to this project, this is a good place to start to figure out how things work. If you have questions not
-covered by these documents, reach out to [#help](https://discord.gg/bPHVcxv) in discord.
+covered by these documents, reach out to [\#help](https://discord.gg/bPHVcxv) in discord.
+ * [Networking][networking]
 
- * [Networking](@ref Networking)
+[networking]: @ref networking
+[networking]: Networking.md
+
+#### {#architecture}

--- a/Documentation/Architecture.md
+++ b/Documentation/Architecture.md
@@ -4,7 +4,8 @@ contribute to this project, this is a good place to start to figure out how thin
 covered by these documents, reach out to [\#help](https://discord.gg/bPHVcxv) in discord.
  * [Networking][networking]
 
-[networking]: @ref networking
-[networking]: Networking.md
 
-#### {#architecture}
+[networking]: Networking.md
+[networking]: @ref networking
+
+#### </b> {#architecture}

--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -829,13 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =  ../Phoenix \
-                          # Fixes extraneous file globbing in the Related Pages
-													# This will need to be manually moderated from now on.
-                          ../CONTRIBUTING.md \
-													../CODE_OF_CONDUCT.md \
-                          ../Documentation/Architecture.md \
-													../Documentation/Networking.md
+INPUT                  =  ../
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/Documentation/Networking.md
+++ b/Documentation/Networking.md
@@ -68,4 +68,4 @@ the Event system is instead used to relay that the action happened.
 
 [InputState]: @ref phx::InputState
 
-#### {#networking}
+#### </b> {#networking}

--- a/Documentation/Networking.md
+++ b/Documentation/Networking.md
@@ -1,32 +1,23 @@
-# Networking Architecure {#Networking}
-
+# Networking Architecure
 This is a generic overview of how the networking system works. If you have additional questions beyond what is
 described here, reach out in [#networking](https://discord.gg/6vwjZhC) on Discord. If you are interested in contributing
 to the networking system, this is also the place to reach out to coordinate any work you want to do.
-
 ## Flow
-
 The data in the networking system is managed in a deterministic lockstep method. This means the server is 100%
 authoritative as to what happens. For some background information on deterministic lockstep check out
 [this article by GlenFelder (Gaffer On Games) is a good read](https://gafferongames.com/post/deterministic_lockstep/).
-
 We process three types of information during runtime. States are non-critical but time-sensitive pieces of information
 that get sent unreliably and are discarded when not received (such as positioning). Events are critical pieces of
 information that are sent via Enet's reliable packet system (Suck as when a block is broken). Messages are essentially
 events but we use a third channel on Enet since they are processed by an entirely separate system.
-
 NOTE: This system's V1 version is a WIP, some information here may describe a future state of the networking system not
 yet implemented.
-
 ### States
-
-[InputState][InputState]s are created by the client every ∆T / game tick (1/20 of a second by default) and queued for transmission.
+[InputState]s are created by the client every ∆T / game tick (1/20 of a second by default) and queued for transmission.
 This happens in a thread so we never run out of time before the next ∆T.
-
 The networking system is then running in another thread `m_iris` watching that queue. It packs states into redundant
 packages (of 5 by default) so each packet will include the X most recent states. This helps prevent packet loss from
 becoming an issue.
-
 When the server gets packets, the networking thread (`m_iris` again) unpacks the data and fills a new queue system with
 any packets it doesn't already have discarding any data it does have or arrived too late. This queue system contains
 StateBundles which are a bundle of InputStates, one from each player for that tick (sequence). When either we have an
@@ -74,4 +65,7 @@ goes wrong.
 side processing. If a Message from the client results in an action (EX: /tp) then there is no client side prediction and
 the Event system is instead used to relay that the action happened.
 
-[InputState]: Phoenix/Common/Include/Common/Input.hpp
+
+[InputState]: @ref phx::InputState
+
+#### {#networking}

--- a/README.md
+++ b/README.md
@@ -53,3 +53,21 @@ need help with.
 <!-- Trying out a hack to work around Doxy not liking to evaluate relative file references directly -->
 [conduct]: CODE_OF_CONDUCT.md
 [conduct]: @ref codeofconduct
+
+[architecture]: Documentation/Architecture.md
+[architecture]: @ref architecture
+
+[contributing]: CONTRIBUTING.md
+[contributing]: @ref contributing
+
+<!--
+	This isn't necessary to make the page the index
+	in Doxygen's output so It's commented out for now.
+	If it's necessary in the future I believe we could
+	just post this at the end of the Level 1 Header
+	and have it work properly. In order to give Doxygen
+	pages explicit names the tag must be on the
+	first Level 1 Header.
+-->
+<!--
+#### <div style="display:none"> {#mainpage} -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GENTEN STUDIOS: PROJECT PHOENIX              {#mainpage}
+# GENTEN STUDIOS: PROJECT PHOENIX
 [![Build Status](https://dev.azure.com/GentenStudios/ProjectPhoenix/_apis/build/status/GentenStudios.Phoenix?branchName=develop)](https://dev.azure.com/GentenStudios/ProjectPhoenix/_build/latest?definitionId=1&branchName=develop)
 ## Introduction
 Project Phoenix is an open world sandbox style voxel game with a twist. The program itself does not provide any content but gets that content entirely from modules written in Lua. An easy to use Lua API provides the capability to define all of the games content in addition to some functional features. This allows content to be quickly created by someone with little to no programming experience while still retaining the power of C++.
@@ -43,10 +43,10 @@ Now follow the platform specific instructions detailed below.
 
 ## Contributing
 We encourage everyone to contribute, this is an open source project that will ultimately be powered by its community. If
-you are interested in contributing check out [our contributing guidelines](contributing.md) for information on how we
+you are interested in contributing check out [our contributing guidelines][contributing] for information on how we
 work and our coding standards. Before you get started, reach out on [\#programming](https://discord.gg/ufJPY5C) on
 discord to collaborate so you aren't duplicating any work. To get an understanding of how our project is designed, check
-out [our architecture documentation](Documentation/Architecture.md). Finally check out
+out [our architecture documentation][architecture]. Finally check out
 [Our issues on GitHub](https://github.com/GentenStudios/Phoenix/issues) for a list of what we currently have planned/
 need help with.
 
@@ -60,14 +60,4 @@ need help with.
 [contributing]: CONTRIBUTING.md
 [contributing]: @ref contributing
 
-<!--
-	This isn't necessary to make the page the index
-	in Doxygen's output so It's commented out for now.
-	If it's necessary in the future I believe we could
-	just post this at the end of the Level 1 Header
-	and have it work properly. In order to give Doxygen
-	pages explicit names the tag must be on the
-	first Level 1 Header.
--->
-<!--
-#### <div style="display:none"> {#mainpage} -->
+<!-- ####  {#mainpage} -->

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
+# GENTEN STUDIOS: PROJECT PHOENIX              {#mainpage}
 [![Build Status](https://dev.azure.com/GentenStudios/ProjectPhoenix/_apis/build/status/GentenStudios.Phoenix?branchName=develop)](https://dev.azure.com/GentenStudios/ProjectPhoenix/_build/latest?definitionId=1&branchName=develop)
-# GENTEN STUDIOS: PROJECT PHOENIX
 ## Introduction
-Project Phoenix is an open world sandbox style voxel game with a twist. The program itself does not provide any content but gets that content entirely from modules written in Lua. An easy to use Lua API provides the capability to define all of the games content in addition to some functional features. This allows content to be quickly created by someone with little to no programming experience while still retaining the power of C++. 
+Project Phoenix is an open world sandbox style voxel game with a twist. The program itself does not provide any content but gets that content entirely from modules written in Lua. An easy to use Lua API provides the capability to define all of the games content in addition to some functional features. This allows content to be quickly created by someone with little to no programming experience while still retaining the power of C++.
 
 More information on this project and its mission can be found [here](https://docs.google.com/document/d/1vwmE24GTWhpxHRwjLutI63bD4uRy_4bxJ21YoKZWDv8).
 
 ## Community
 [Here's a link to our public discord server](https://discord.gg/XRttqAm), where we collaborate and discuss the development of the Phoenix.
 
-[Here's a link to our community guidelines](CODE_OF_CONDUCT.md)
+[Here's a link to our community guidelines][conduct]
 
 ## Dependencies
 - CMake (Version >= 3.0)
@@ -37,14 +37,19 @@ Now follow the platform specific instructions detailed below.
   - And voila, all done. Now you should be able to run the project!
 
 ### Linux, Mac OS X, MSYS
- 
+
   - Navigate to the `Build/Phoenix` folder and run `./Phoenix` to run the executable.
 
+
 ## Contributing
-We encourage everyone to contribute, this is an open source project that will ultimately be powered by its community. If 
-you are interested in contributing check out [our contributing guidelines](CONTRIBUTING.md) for information on how we 
-work and our coding standards. Before you get started, reach out on [#programming](https://discord.gg/ufJPY5C) on 
-discord to collaborate so you aren't duplicating any work. To get an understanding of how our project is designed, check 
-out [our architecture documentation](Documentation/Architecture.md). Finally check out 
-[Our issues on GitHub](https://github.com/GentenStudios/Phoenix/issues) for a list of what we currently have planned/ 
+We encourage everyone to contribute, this is an open source project that will ultimately be powered by its community. If
+you are interested in contributing check out [our contributing guidelines](contributing.md) for information on how we
+work and our coding standards. Before you get started, reach out on [\#programming](https://discord.gg/ufJPY5C) on
+discord to collaborate so you aren't duplicating any work. To get an understanding of how our project is designed, check
+out [our architecture documentation](Documentation/Architecture.md). Finally check out
+[Our issues on GitHub](https://github.com/GentenStudios/Phoenix/issues) for a list of what we currently have planned/
 need help with.
+
+<!-- Trying out a hack to work around Doxy not liking to evaluate relative file references directly -->
+[conduct]: CODE_OF_CONDUCT.md
+[conduct]: @ref codeofconduct


### PR DESCRIPTION
Fixes Doxygen link resolution while keeping link resolution on Github intact. This work is the result of 14+ hours testing different implementations to find the best. And this is it! I truncated the extra test commits I made from the original branch this was on as to not clusterfuck the tree.

## Summary of changes
-  Markdown files can now link to each other in Doxygen.
  
## Caveats
-  Github's Markdown parser doesn't filter the extra reference style link tag and instead confuses it with a reference pointer, which leaves some text artifacts behind due to the Doxygen style links.
- In order to generate the Doxygen HTML tag name needed to link Markdown pages together, a Level 4 Markdown header is placed at the bottom of every page. *Which is only visible on Github :woman_facepalming:*.


### Now ***I*** need to sleep. **Holy crap!** :zzz: :sleeping_bed:

